### PR TITLE
glm include dir

### DIFF
--- a/vendor/glm/CMakeLists.txt
+++ b/vendor/glm/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(GLM_LIB STATIC ${CMAKE_CURRENT_LIST_DIR}/src/Empty.cpp)
 
-target_include_directories(GLM_LIB PUBLIC "${CMAKE_CURRENT_LIST_DIR}/ext/")
+target_include_directories(GLM_LIB PUBLIC "${CMAKE_CURRENT_LIST_DIR}/ext/glm")


### PR DESCRIPTION
Editing glm include directory path so includes are more convenient (<glm/..> instead of <glm/glm/...>)